### PR TITLE
Fix the "Suspend" button-text bug

### DIFF
--- a/project/src/ui/sketch_control/ControlPane.gd
+++ b/project/src/ui/sketch_control/ControlPane.gd
@@ -269,6 +269,8 @@ func _on_reset_pos() -> void:
 
 
 func _on_start() -> void:
+	pause_btn.text = "Suspend"
+	
 	match _board.status():
 		SMCE.Status.RUNNING, SMCE.Status.SUSPENDED:
 			Util.print_if_err(_board.terminate())


### PR DESCRIPTION
When a vehicle is stopped and then started, the Resume/Suspend button should say "Suspend". If the button said "Resume" before stopping and starting the car, "Resume" would still be there. It is fixed and now the button is set to "Suspend" when the car is stopped.

Video of original problem: https://drive.google.com/file/d/1gv60QdW_Y4D3gbEoZJ1TlhOemSxSxJyj/view?usp=sharing